### PR TITLE
pybase64 1.4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,10 @@ requirements:
 test:
   imports:
     - pybase64
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/mayeut/pybase64/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pybase64" %}
-{% set version = "1.2.3" %}
-{% set sha256 = "76d074df9a7b989b3589926ab1946677bbb399ecfe230714b13157e2633611ed" %}
+{% set version = "1.4.3" %}
+{% set sha256 = "c2ed274c9e0ba9c8f9c4083cfe265e66dd679126cd9c2027965d807352f3f053" %}
 
 package:
   name: {{ name|lower }}
@@ -11,17 +11,22 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true # [py<310]
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - pybase64=pybase64.__main__:main
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
@@ -35,6 +40,9 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Fast Base64 encoding/decoding in Python
+  description: |
+    This project is a wrapper on libbase64. It aims to provide a fast base64 implementation for 
+    base64 encoding/decoding using the same interface as Python's base64 modern interface.
   doc_url: https://github.com/mayeut/pybase64/
   dev_url: https://github.com/mayeut/pybase64/
 


### PR DESCRIPTION
pybase64 1.4.3

**Destination channel:** defaults

### Links

- [PKG-12048](https://anaconda.atlassian.net/browse/PKG-12048) 
- Upstream repo: https://github.com/mayeut/pybase64/
- Upstream release notes: https://github.com/mayeut/pybase64/releases
- Conda-forge repo: https://github.com/conda-forge/pybase64-feedstock

### Explanation of changes:

- First release to the main channel. Please review the whole recipe.
- Part of the vLLM dependency chain

[PKG-12048]: https://anaconda.atlassian.net/browse/PKG-12048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ